### PR TITLE
VS Code compatibility and other fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*
+!*.*
+*.debug
+*.exe
+/.bmx
+/.vscode

--- a/bmf.bmx
+++ b/bmf.bmx
@@ -16,6 +16,13 @@ BMF - Blitzmax code formatter
 
 EndRem
 
+SuperStrict
+
+Framework brl.standardio
+Import brl.system
+Import brl.linkedlist
+Import brl.threads
+Import brl.stringbuilder
 
 'Start from command line
 If AppArgs And AppArgs.length > 1 Then
@@ -200,47 +207,24 @@ Type TBMaxCode
 		Return True
 	EndFunction
 	
-	Method Parse:String(txt:String = "")
-		
-		If optStdIn Then 
-			txt = ReadStdin()
-		EndIf
-		
-		DebugLog "Parse: txt = " + txt
-		
-		Return _parse(txt)
-		
-	EndMethod
-	
 	Method SetActive()
 		
 		Local str:TBMFStream = TBMFStream.Create()
-		Local s:String, isCatched:Int
+		Local s:String
+		Local txt:String
 		
-		While True
-			Try
-				While True
+		Try
+			Repeat
 
-					s = str.ReadString(1)   'myReadStdin()
-					str.text.append(s)
-					
-					'WriteStdout( s + " = " + s[0] + "~n")
-				Wend
-
-			Catch o:Object
-				
-				isCatched = True
-				WriteStdout(str.text.ToString())
-				
-			EndTry
-			
-			If Not isCatched Then
-				WriteStdout(str.text.ToString())
-			EndIf
-			
-			isCatched = False
-		Wend
+				s = str.ReadString(1)
+				str.text.append(s)
+			Forever
 		
+		Catch o:Object
+			
+			txt = str.text.ToString()
+			WriteStdout(_parse(txt))
+		EndTry
 	EndMethod
 	
 	Method SetKeywords()


### PR DESCRIPTION
Removed unused Parse function
Added framework and imports
Added .gitignore file

---

These fixes ensures that the formatter works with VS Code.
It also makes terminal input work via something like: `echo framework | ./bmf -stdio` and other similar tools.
_(only tested on Linux)_
And I noticed that the `Parse` function was never called, so I removed that _(I got confused when there was `_parse` and `Parse`)_.
I also went ahead and added a framework module and imports to cut down on file size and compile time, along with a **.gitignore** file so I didn't have to unstage the entire **.bmx** folder. 

![deepin-screen-recorder_Select area_20210426120822](https://user-images.githubusercontent.com/1727541/116066383-4d71d180-a688-11eb-8113-f1799d4e2245.gif)
